### PR TITLE
fix(docs): Fix typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For general info check out the [Übersicht website.](http://tracesof.net/uebersi
 
 In essence, widgets are JavaScript modules that expose a few key properties and methods. They need to be defined in a single file with a `.jsx` extension for Übersicht to pick them up. Previously, widgets could be written in CoffeeScript and are still supported. Check [the old documentation](ClassicWidgets.md) for details. Übersicht will listen to file changes inside your widget directory, so you can edit widgets and see the result live.
 
-Widget rendering is done using [React](https://reactjs.org) and it's [JSX](https://reactjs.org/docs/introducing-jsx.html) syntax. Simple widget state is managed for you by Übersicht, but for more advanced widgets you can manage state using a Redux-like pattern. You `dispatch` events, which get processed by a single `updateState` function which returns the new state, which is passed to the render function of your widget.
+Widget rendering is done using [React](https://reactjs.org) and its [JSX](https://reactjs.org/docs/introducing-jsx.html) syntax. Simple widget state is managed for you by Übersicht, but for more advanced widgets you can manage state using a Redux-like pattern. You `dispatch` events, which get processed by a single `updateState` function which returns the new state, which is passed to the render function of your widget.
 
 State is kept when you modify your widget, which allows for live coding. Any changes to the UI of your widget will be immediatly visible.  One drawback (at least with the current implementation) is that if you change the shape of your state you mighy have to 'Refresh all Widgets' from the app menu for your widget to work.
 


### PR DESCRIPTION
### What does this PR do?
Fixes a baby "it's" => "its" typo in the README doc. 🤓